### PR TITLE
Allow to add query parameters for a request

### DIFF
--- a/core/src/main/scala/client/GrafanaClient.scala
+++ b/core/src/main/scala/client/GrafanaClient.scala
@@ -35,7 +35,6 @@ case class GrafanaClient[F[_]](config: GrafanaConfig, backend: SttpBackend[F, An
       .get(
         params
           .foldLeft(uri"$url/api/search")((url, params) => url.addParam(params._1, params._2))
-          .addParam("limit", "5000")
       )
       .response(asJsonEither[ErrorResponse, Seq[DashboardSnippet]])
       .send(backend)

--- a/core/src/main/scala/client/GrafanaClient.scala
+++ b/core/src/main/scala/client/GrafanaClient.scala
@@ -20,16 +20,6 @@ case class GrafanaClient[F[_]](config: GrafanaConfig, backend: SttpBackend[F, An
     }
   }
 
-  def search(): F[Response[Either[ResponseException[ErrorResponse, circe.Error], Seq[DashboardSnippet]]]] = {
-    grafanaRequest
-      .get(
-        uri"$url/api/search"
-          .addParam("limit", "5000")
-      )
-      .response(asJsonEither[ErrorResponse, Seq[DashboardSnippet]])
-      .send(backend)
-  }
-
   /**
    * Allow to add query parameters for a request.
    *

--- a/core/src/main/scala/client/GrafanaClient.scala
+++ b/core/src/main/scala/client/GrafanaClient.scala
@@ -30,6 +30,27 @@ case class GrafanaClient[F[_]](config: GrafanaConfig, backend: SttpBackend[F, An
       .send(backend)
   }
 
+  /**
+   * Allow to add query parameters for a request.
+   *
+   * e.g. [[https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/]]
+   * @author vl0ft
+   * @param params map of query parameters
+   * @return response
+   */
+  def search(
+      params: Map[String, String])
+  : F[Response[Either[ResponseException[ErrorResponse, circe.Error], Seq[DashboardSnippet]]]] = {
+    grafanaRequest
+      .get(
+        params
+          .foldLeft(uri"$url/api/search")((url, params) => url.addParam(params._1, params._2))
+          .addParam("limit", "5000")
+      )
+      .response(asJsonEither[ErrorResponse, Seq[DashboardSnippet]])
+      .send(backend)
+  }
+
   def getDashboard(uid: String): F[Response[Either[ResponseException[ErrorResponse, circe.Error], Dashboard]]] = {
     dashboardInner(asJsonEither[ErrorResponse, Dashboard])(uid)
   }

--- a/core/src/test/scala/DashboardSearchSpec.scala
+++ b/core/src/test/scala/DashboardSearchSpec.scala
@@ -1,0 +1,98 @@
+package scalograf
+
+import com.dimafeng.testcontainers.ContainerDef
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import io.circe.parser.parse
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AsyncWordSpec
+import scalograf.client.{DashboardUploadRequest, GrafanaClient, GrafanaConfig}
+import scalograf.client.GrafanaConfig.{LoginPassword, Scheme}
+import scalograf.model.Dashboard
+import sttp.client3.HttpError
+import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
+
+import java.io.File
+import scala.concurrent.Future
+import scala.io.Source
+
+class DashboardSearchSpec extends AsyncWordSpec with should.Matchers with OptionValues with TestContainerForAll {
+  val testDataDir = new File(getClass.getResource("/testDashboards").getPath)
+  override val containerDef: ContainerDef = GrafanaContainer.Def()
+
+  "Grafana client" should {
+    s"not found folders" in withContainers {
+      case container: GrafanaContainer =>
+        println(container.url)
+        val client = GrafanaClient(
+          GrafanaConfig(
+            Scheme("http", container.host, container.port),
+            LoginPassword("admin", "admin")
+          ),
+          AsyncHttpClientFutureBackend()
+        )
+
+        Future
+          .traverse(testDataDir.listFiles().toList) { dashboardFile =>
+            val dashboardJson = parse(Source.fromFile(dashboardFile).getLines().mkString) match {
+              case Left(value)  => throw value
+              case Right(value) => value
+            }
+            val dashboard = dashboardJson.as[Dashboard] match {
+              case Left(value)  => throw value
+              case Right(value) => value
+            }
+
+            client
+              .uploadDashboard(DashboardUploadRequest(dashboard))
+              .flatMap { _ => client.search(Map("type" -> "dash-folder"))}
+              .map(_.body)
+              .map { body =>
+                println(s"${dashboard.gnetId} $body")
+                body match {
+                  case Right(listOfFolders) => Right(listOfFolders.isEmpty)
+                  case l @ Left(HttpError(b, status)) if dashboard.__inputs.nonEmpty => l
+                }
+              }
+          }
+          .map(_ => assert(true))
+    }
+
+    s"found dashboards" in withContainers {
+      case container: GrafanaContainer =>
+        println(container.url)
+        val client = GrafanaClient(
+          GrafanaConfig(
+            Scheme("http", container.host, container.port),
+            LoginPassword("admin", "admin")
+          ),
+          AsyncHttpClientFutureBackend()
+        )
+
+        Future
+          .traverse(testDataDir.listFiles().toList) { dashboardFile =>
+            val dashboardJson = parse(Source.fromFile(dashboardFile).getLines().mkString) match {
+              case Left(value)  => throw value
+              case Right(value) => value
+            }
+            val dashboard = dashboardJson.as[Dashboard] match {
+              case Left(value)  => throw value
+              case Right(value) => value
+            }
+
+            client
+              .uploadDashboard(DashboardUploadRequest(dashboard))
+              .flatMap { _ => client.search(Map("type" -> "dash-db"))}
+              .map(_.body)
+              .map { body =>
+                println(s"${dashboard.gnetId} $body")
+                body match {
+                  case Right(listOfFolders) => Right(listOfFolders.nonEmpty)
+                  case l @ Left(HttpError(b, status)) if dashboard.__inputs.nonEmpty => l
+                }
+              }
+          }
+          .map(_ => assert(true))
+    }
+  }
+}


### PR DESCRIPTION
Добавил возможность передавать параметры в метод `search` для клиента. Выбирать просто 5000 сущностей из всего не очень.

Оставил принудительное ограничение на 5000 элементов в выборке.